### PR TITLE
Update Package.targets

### DIFF
--- a/build/Package.targets
+++ b/build/Package.targets
@@ -9,14 +9,14 @@
     <XmlRead Prefix="n"
                    Namespace="http://schemas.microsoft.com/developer/msbuild/2003"
                    XPath="dotnetnuke/packages/package/@version"
-                   XmlFileName="$(DNNFileName).dnn">
+                   XmlFileName="$(DNNFileName)">
       <Output TaskParameter="Value" PropertyName="Version" />
     </XmlRead>
-    <ExtensionPackager Manifest="$(DNNFileName).dnn" WorkingFolder="$(MSBuildProjectDirectory)\">
+    <ExtensionPackager Manifest="$(DNNFileName)" WorkingFolder="$(MSBuildProjectDirectory)\">
       <Output TaskParameter="PackageFiles" PropertyName="PackageFiles">
       </Output>
     </ExtensionPackager>
-    <Copy SourceFiles="$(DNNFileName).dnn" DestinationFolder="$(MSBuildProjectDirectory)\Package" />
+    <Copy SourceFiles="$(DNNFileName)" DestinationFolder="$(MSBuildProjectDirectory)\Package" />
     <Zip Files="@(Resources)" WorkingDirectory="$(MSBuildProjectDirectory)" ZipFileName="$(MSBuildProjectDirectory)\Package\Resources.zip" />
     <ItemGroup>
       <LicenseFiles Include="license.txt"/>


### PR DESCRIPTION
Release build fails due to looking for manifest files with double extension.  Removed extra extension ".dnn" from references to "$(DNNFileName).dnn" in this file.  Now building in release mode works.
